### PR TITLE
Fix exportfs string for disabling zfs_snapdir (#2)

### DIFF
--- a/support/nfs/exports.c
+++ b/support/nfs/exports.c
@@ -587,7 +587,7 @@ parseopts(char *cp, struct exportent *ep, int warn, int *had_subtree_opt_ptr)
 		/* Add TrueNAS-specific changes */
 		else if (!strcmp(opt, "zfs_snapdir"))
 			setflags(NFSEXP_SNAPDIR, active, ep);
-		else if (!strcmp(opt, "no_zfs_snapdir"))
+		else if (!strcmp(opt, "nozfs_snapdir"))
 			clearflags(NFSEXP_SNAPDIR, active, ep);
 		/* End  TrueNAS */
 		else if (!strcmp(opt, "wdelay"))


### PR DESCRIPTION
This should be nozfs_snapdir rather than no_zfs_snapdir.