### PR TITLE
Nas 137171 / 25.04.2.3 / Backport upstream nfs-utils fixes for HA failover

### DIFF
--- a/support/nfs/exports.c
+++ b/support/nfs/exports.c
@@ -587,7 +587,7 @@ parseopts(char *cp, struct exportent *ep, int warn, int *had_subtree_opt_ptr)
 		/* Add TrueNAS-specific changes */
 		else if (!strcmp(opt, "zfs_snapdir"))
 			setflags(NFSEXP_SNAPDIR, active, ep);
-		else if (!strcmp(opt, "no_zfs_snapdir"))
+		else if (!strcmp(opt, "nozfs_snapdir"))
 			clearflags(NFSEXP_SNAPDIR, active, ep);
 		/* End  TrueNAS */
 		else if (!strcmp(opt, "wdelay"))

--- a/systemd/nfs.conf.man
+++ b/systemd/nfs.conf.man
@@ -166,6 +166,7 @@ for details.
 Recognized values:
 .BR threads ,
 .BR host ,
+.BR scope ,
 .BR port ,
 .BR grace-time ,
 .BR lease-time ,

--- a/utils/nfsd/nfsd.man
+++ b/utils/nfsd/nfsd.man
@@ -38,7 +38,7 @@ request on all known network addresses.  This may change in future
 releases of the Linux Kernel. This option can be used multiple times
 to listen to more than one interface.
 .TP
-.B \S " or " \-\-scope scope
+.B \-S " or " \-\-scope scope
 NFSv4.1 and later require the server to report a "scope" which is used
 by the clients to detect if two connections are to the same server.
 By default Linux NFSD uses the host name as the scope.

--- a/utils/nfsd/nfsd.man
+++ b/utils/nfsd/nfsd.man
@@ -35,8 +35,16 @@ Note that
 .B lockd
 (which performs file locking services for NFS) may still accept
 request on all known network addresses.  This may change in future
-releases of the Linux Kernel. This option can be used multiple time 
+releases of the Linux Kernel. This option can be used multiple times
 to listen to more than one interface.
+.TP
+.B \S " or " \-\-scope scope
+NFSv4.1 and later require the server to report a "scope" which is used
+by the clients to detect if two connections are to the same server.
+By default Linux NFSD uses the host name as the scope.
+.sp
+It is particularly important for high-availablity configurations to ensure
+that all potential server nodes report the same server scope.
 .TP
 .B \-p " or " \-\-port  port
 specify a different port to listen on for NFS requests. By default,
@@ -133,6 +141,9 @@ A host name, or comma separated list of host names, that
 will listen on.  Use of the
 .B --host
 option replaces all host names listed here.
+.TP
+.B scope
+Set the server scope.
 .TP
 .B grace-time
 The grace time, for both NFSv4 and NLM, in seconds.


### PR DESCRIPTION
Backport cherry-pick commits to enable support for `scope` setting.