### PR TITLE
Disable using directories to hold NFS share configuration.

### DIFF
--- a/support/export/export.c
+++ b/support/export/export.c
@@ -168,6 +168,8 @@ export_d_read(const char *dname, int ignore_hosts)
 	struct dirent **namelist = NULL;
 	int volumes = 0;
 
+	/* TrueNAS: disable exports from any directory */
+	return 0;
 
 	n = scandir(dname, &namelist, NULL, versionsort);
 	if (n < 0) {


### PR DESCRIPTION
Add early return to always report the selected directory contains `0` files to process.
An export directory is read in two places:

1. `nfs-utils/systemd/nfs-server-generator.c`
2. `nfs-utils/utils/exportfs/exportfs.c`

All NFS share configuration must be in the `/etc/exports` file.