### PR TITLE
NAS-140474 / 25.10.2.2 / mountd: reduce negative cache TTL for zfs_snapdir exports (by ixhamza)

### DIFF
--- a/support/export/cache.c
+++ b/support/export/cache.c
@@ -809,6 +809,7 @@ static void nfsd_fh(int f)
 	nfs_export *exp;
 	int i;
 	int dev_missing = 0;
+	int has_snapdir = 0;
 	char buf[RPC_CHAN_BUF_SIZE], *bp;
 	int blen;
 
@@ -875,6 +876,8 @@ static void nfsd_fh(int f)
 			if (!is_ipaddr_client(dom)
 					&& !namelist_client_matches(exp, dom))
 				continue;
+			if (exp->m_export.e_flags & NFSEXP_SNAPDIR)
+				has_snapdir = 1;
 			if (exp->m_export.e_mountpoint &&
 			    !is_mountpoint(exp->m_export.e_mountpoint[0]?
 					   exp->m_export.e_mountpoint:
@@ -944,8 +947,17 @@ static void nfsd_fh(int f)
 	 * remove this from the kernel, so use a really log
 	 * timeout.  Maybe this should be configurable on the command
 	 * line.
+	 *
+	 * For negative responses with zfs_snapdir exports, use a
+	 * short TTL. ZFS snapshots mount and unmount dynamically,
+	 * so a snapshot that is unavailable now may be automounted
+	 * shortly after. A permanent negative would prevent the
+	 * kernel from ever retrying the fsid resolution.
 	 */
-	qword_addint(&bp, &blen, 0x7fffffff);
+	if (!found && has_snapdir)
+		qword_addint(&bp, &blen, time(0) + 30);
+	else
+		qword_addint(&bp, &blen, 0x7fffffff);
 	if (found)
 		qword_add(&bp, &blen, found_path);
 	qword_addeol(&bp, &blen);


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x 416040d9c27e4eed9940f1e1e6a8222ff5e413a3

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x aec1232ec9aee797e53576e3b4e5196c751f4314

When mountd cannot resolve a fsid to a path (e.g., because the snapshot is temporarily unmounted), it writes a negative response to the nfsd.fh cache with `TTL=0x7fffffff`. This permanently prevents the kernel from retrying the resolution, even after the snapshot is re-mounted via automount. The only recovery is exportfs -f on the server or a full NFS service restart.

With zfs_snapdir exports, snapshots mount and unmount dynamically (automount on access, unmount on expire or `zfs recv -F`). A negative that is correct now may become wrong seconds later. Use a 30-second TTL for negative responses when any matching export has the zfs_snapdir flag, so the kernel retries and picks up the newly mounted snapshot.

### Testing
```bash
# Server: setup pool, snapshots, and export with zfs_snapdir.
# expire=5 means snapshots unmount after 5s of idle time.
zpool destroy tank 2>/dev/null; echo "" > /etc/exports; exportfs -r
zpool create -f tank -O mountpoint=/mnt/tank sda
zfs create tank/target
dd if=/dev/urandom of=/mnt/tank/target/bigfile bs=1M count=5
for i in 1 2 3 4 5; do echo "snap${i}" > /mnt/tank/target/file${i}.txt; zfs snapshot tank/target@snap${i}; done
echo 5 > /sys/module/zfs/parameters/zfs_expire_snapshot
echo '"/mnt/tank/target" *(rw,sync,no_subtree_check,no_root_squash,zfs_snapdir)' > /etc/exports
exportfs -ra

# Client: access triggers automount with 5s expire timer
sudo umount /mnt/tank 2>/dev/null; sudo mkdir -p /mnt/tank
sudo mount -t nfs4 -o vers=4.2 192.168.18.9:/mnt/tank/target /mnt/tank
ls /mnt/tank/.zfs/snapshot/snap1/    # works

# Server: wait for expire to unmount snapshots and poison nfsd.fh cache.
# The expire unmounts the snapshot, zfsctl_snapshot_unmount() calls
# exportfs_flush() which wipes the nfsd.fh cache, and mountd returns
# a negative with TTL=0x7fffffff because the snapshot is unmounted.
# Then set expire=0 to prevent further flushes from clearing the negative.
sleep 30
echo 0 > /sys/module/zfs/parameters/zfs_expire_snapshot

# Client: ESTALE — permanent without the fix.
# The snapshot re-mounts via automount on the server, but the permanent
# negative in nfsd.fh sits in front and returns ESTALE without ever
# reaching the filesystem. Only exportfs -f clears it.
# With the fix (30s TTL), the negative expires and self-resolves.
ls /mnt/tank/.zfs/snapshot/snap1/    # Stale file handle

# Server: only exportfs -f fixes it (without the TTL fix)
exportfs -f

# Client: recovered
ls /mnt/tank/.zfs/snapshot/snap1/    # works
```

Original PR: https://github.com/truenas/nfs-utils/pull/10
